### PR TITLE
Adding watching-only create to Loader and Wallet

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3620,23 +3620,45 @@ func (w *Wallet) Database() walletdb.DB {
 // Create creates an new wallet, writing it to an empty database.  If the passed
 // seed is non-nil, it is used.  Otherwise, a secure random seed of the
 // recommended length is generated.
-func Create(db walletdb.DB, pubPass, privPass, seed []byte, params *chaincfg.Params,
-	birthday time.Time) error {
+func Create(db walletdb.DB, pubPass, privPass, seed []byte,
+	params *chaincfg.Params, birthday time.Time) error {
 
-	// If a seed was provided, ensure that it is of valid length. Otherwise,
-	// we generate a random seed for the wallet with the recommended seed
-	// length.
-	if seed == nil {
-		hdSeed, err := hdkeychain.GenerateSeed(
-			hdkeychain.RecommendedSeedLen)
-		if err != nil {
-			return err
+	return createInternal(
+		db, pubPass, privPass, seed, params, birthday, false,
+	)
+}
+
+// CreateWatchingOnly creates an new watch-only wallet, writing it to
+// an empty database. No seed can be provided as this wallet will be
+// watching only.  Likewise no private passphrase may be provided
+// either.
+func CreateWatchingOnly(db walletdb.DB, pubPass []byte,
+	params *chaincfg.Params, birthday time.Time) error {
+
+	return createInternal(
+		db, pubPass, nil, nil, params, birthday, true,
+	)
+}
+
+func createInternal(db walletdb.DB, pubPass, privPass, seed []byte,
+	params *chaincfg.Params, birthday time.Time, isWatchingOnly bool) error {
+
+	if !isWatchingOnly {
+		// If a seed was provided, ensure that it is of valid length. Otherwise,
+		// we generate a random seed for the wallet with the recommended seed
+		// length.
+		if seed == nil {
+			hdSeed, err := hdkeychain.GenerateSeed(
+				hdkeychain.RecommendedSeedLen)
+			if err != nil {
+				return err
+			}
+			seed = hdSeed
 		}
-		seed = hdSeed
-	}
-	if len(seed) < hdkeychain.MinSeedBytes ||
-		len(seed) > hdkeychain.MaxSeedBytes {
-		return hdkeychain.ErrInvalidSeedLen
+		if len(seed) < hdkeychain.MinSeedBytes ||
+			len(seed) > hdkeychain.MaxSeedBytes {
+			return hdkeychain.ErrInvalidSeedLen
+		}
 	}
 
 	return walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
@@ -3650,8 +3672,7 @@ func Create(db walletdb.DB, pubPass, privPass, seed []byte, params *chaincfg.Par
 		}
 
 		err = waddrmgr.Create(
-			addrmgrNs, seed, pubPass, privPass, params, nil,
-			birthday,
+			addrmgrNs, seed, pubPass, privPass, params, nil, birthday,
 		)
 		if err != nil {
 			return err

--- a/wallet/watchingonly_test.go
+++ b/wallet/watchingonly_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+)
+
+// TestCreateWatchingOnly checks that we can construct a watching-only
+// wallet.
+func TestCreateWatchingOnly(t *testing.T) {
+	// Set up a wallet.
+	dir, err := ioutil.TempDir("", "watchingonly_test")
+	if err != nil {
+		t.Fatalf("Failed to create db dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	pubPass := []byte("hello")
+
+	loader := NewLoader(&chaincfg.TestNet3Params, dir, true, 250)
+	_, err = loader.CreateNewWatchingOnlyWallet(pubPass, time.Now())
+	if err != nil {
+		t.Fatalf("unable to create wallet: %v", err)
+	}
+}


### PR DESCRIPTION
Questions:
For both the Loader and the Wallet I created an "internal" method with an extra `isWatchingOnly` boolean arg and then made the public facing methods trivially call it.
1. Is the name `createNewWalletInternal` ok?  Should the "Internal" be something else?
2. Maybe I should make the new function public, like `CreateNewWalletExtended`, this would make things easier on callers w/ both situations.

I added a unit test, but quickly got bogged down trying to show that there were no accounts, add one and then show the new account.  My suspicion is that the interface at this level isn't really thought out yet?  Do we really need to dig the db out to add an account?  The "layering" feels messed up.

Should we try and defer these issues till we've got an actual use case?  Or do we resolve them with guesses?